### PR TITLE
prevent "po2lmo: command not found" error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -71,6 +71,7 @@ cat feeds.conf.default
 ./scripts/feeds install -a
 echo CONFIG_ALL=y >.config
 make defconfig
+make V=s ./package/feeds/luci/luci-base/compile
 make V=s ./package/feeds/githubaction/${PKGNAME}/compile
 
 find bin -type f -exec ls -lh {} \;


### PR DESCRIPTION
如果不先编译`luci-base`，编译某些具有luci依赖（带有国际化翻译？）的插件会出现`bash: po2lmo: command not found`错误。
当然，强制编译`luci-base`，对于没有luci依赖的插件编译是多余的，会增加不必要的编译时间。

```
2023-02-13T07:16:37.0392128Z make[2]: Entering directory '/home/runner/work/gl-sdk-action/gl-sdk-action/buildsource/OpenClash/luci-app-openclash'
2023-02-13T07:16:37.2970961Z touch /home/runner/work/gl-sdk-action/gl-sdk-action/openwrt-sdk/build_dir/target-aarch64_cortex-a53_musl/luci-app-openclash/.prepared_0618fc3d3586edba129d79bb59496b02_18f1e190c5d53547fed41a3eaa76e9e9_check
2023-02-13T07:16:37.3004646Z cp -fpR /home/runner/work/gl-sdk-action/gl-sdk-action/buildsource/OpenClash/luci-app-openclash/root /home/runner/work/gl-sdk-action/gl-sdk-action/openwrt-sdk/build_dir/target-aarch64_cortex-a53_musl/luci-app-openclash
2023-02-13T07:16:37.3281927Z cp -fpR /home/runner/work/gl-sdk-action/gl-sdk-action/buildsource/OpenClash/luci-app-openclash/luasrc /home/runner/work/gl-sdk-action/gl-sdk-action/openwrt-sdk/build_dir/target-aarch64_cortex-a53_musl/luci-app-openclash
2023-02-13T07:16:37.3347123Z po2lmo /home/runner/work/gl-sdk-action/gl-sdk-action/buildsource/OpenClash/luci-app-openclash/po/zh-cn/openclash.zh-cn.po /home/runner/work/gl-sdk-action/gl-sdk-action/openwrt-sdk/build_dir/target-aarch64_cortex-a53_musl/luci-app-openclash/openclash.zh-cn.lmo;
2023-02-13T07:16:37.3365941Z bash: po2lmo: command not found
2023-02-13T07:16:37.3367483Z make[2]: Leaving directory '/home/runner/work/gl-sdk-action/gl-sdk-action/buildsource/OpenClash/luci-app-openclash'
2023-02-13T07:16:37.3371033Z make[2]: *** [Makefile:155: /home/runner/work/gl-sdk-action/gl-sdk-action/openwrt-sdk/build_dir/target-aarch64_cortex-a53_musl/luci-app-openclash/.prepared_0618fc3d3586edba129d79bb59496b02_18f1e190c5d53547fed41a3eaa76e9e9] Error 127
2023-02-13T07:16:37.3374271Z time: package/feeds/githubaction/luci-app-openclash/compile#0.24#0.11#0.31
2023-02-13T07:16:37.3381428Z     ERROR: package/feeds/githubaction/luci-app-openclash failed to build.
2023-02-13T07:16:37.3386667Z make[1]: *** [package/Makefile:118: package/feeds/githubaction/luci-app-openclash/compile] Error 1
2023-02-13T07:16:37.3393468Z make[1]: Leaving directory '/home/runner/work/gl-sdk-action/gl-sdk-action/openwrt-sdk'
2023-02-13T07:16:37.3400677Z make: *** [/home/runner/work/gl-sdk-action/gl-sdk-action/openwrt-sdk/include/toplevel.mk:223: package/feeds/githubaction/luci-app-openclash/compile] Error 2
```